### PR TITLE
Update new views Order on Contextual Filters

### DIFF
--- a/config/install/views.view.osu_stories.yml
+++ b/config/install/views.view.osu_stories.yml
@@ -1,3 +1,4 @@
+uuid: edd70529-852b-43ee-aa4e-7ab159e7d4e9
 langcode: en
 status: true
 dependencies:
@@ -10,7 +11,6 @@ dependencies:
     - taxonomy.vocabulary.tags
   module:
     - date_ap_style
-    - osu_media
     - link
     - media
     - node
@@ -924,6 +924,42 @@ display:
           offset: 0
           items_per_page: 4
       arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: true
         tid:
           id: tid
           table: taxonomy_index
@@ -962,46 +998,10 @@ display:
             type: none
             fail: 'not found'
           validate_options: {  }
-          break_phrase: false
+          break_phrase: true
           add_table: false
           require_value: false
-          reduce_duplicates: false
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: node
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            override: false
-            items_per_page: 25
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: true
+          reduce_duplicates: true
       style:
         type: views_bootstrap_grid
         options:


### PR DESCRIPTION
The order of the Contextual Filters for the Related stories does matter and we need to exclude the node first then include all other tags.