### PR TITLE
Update description of story external URL field

### DIFF
--- a/config/install/field.field.node.story.field_osu_story_external_url.yml
+++ b/config/install/field.field.node.story.field_osu_story_external_url.yml
@@ -11,7 +11,7 @@ field_name: field_osu_story_external_url
 entity_type: node
 bundle: story
 label: 'Story External URL'
-description: ''
+description: 'Put a URL here if you want to link to story on another website and not write your own story.'
 required: false
 translatable: false
 default_value: {  }

--- a/osu_story.install
+++ b/osu_story.install
@@ -18,3 +18,20 @@ function osu_story_update_9001(&$sandbox) {
   $config_storage->write('core.entity_view_display.node.story.teaser', $source->read('core.entity_view_display.node.story.teaser'));
   return t('Add/updated the metatag defaults for OSU Story.');
 }
+
+/**
+ * Update the description of field_osu_story_external_url
+ */
+function osu_story_update_9002(&$sandbox) {
+  /** @var \Drupal\Core\Config\CachedStorage $config_storage */
+  $config_storage = \Drupal::service('config.storage');
+
+  // Load the field's existing configuration.
+  $field_config = $config_storage->read('field.field.node.story.field_osu_story_external_url');
+  // Update the description.
+  $field_config['description'] = 'Put a URL here if you want to link to story on another website and not write your own story.';
+  // Write the updated configuration back.
+  $config_storage->write('field.field.node.story.field_osu_story_external_url', $field_config);
+
+  return t('Updated the description of field_osu_story_external_url for OSU Story.');
+}


### PR DESCRIPTION
The commit adds a more detailed description to the 'field_osu_story_external_url' field. The description guides users to put a URL in the field if they wish to link to an external story instead. The change is deployed by implementing an update hook in 'osu_story.install'.

Closes osu-wams/madrone#169