### PR TITLE
Remove twitter card image dimensions from metatag config

### DIFF
--- a/config/install/metatag.metatag_defaults.node__story.yml
+++ b/config/install/metatag.metatag_defaults.node__story.yml
@@ -11,6 +11,4 @@ tags:
   og_image_width: '1200'
   twitter_cards_image: '[node:field_osu_story_cover_image:entity:field_media_image:twitter_300x157]'
   twitter_cards_image_alt: '[node:field_osu_story_cover_image:entity:field_media_image:alt]'
-  twitter_cards_image_height: '300'
-  twitter_cards_image_width: '157'
   twitter_cards_type: summary_large_image


### PR DESCRIPTION
The dimensions of the Twitter card image have been removed from the metatag configuration for story nodes. Removing these settings will let Twitter automatically choose the best dimensions for the displayed image. This change is part of preparations for the upcoming release.