### PR TITLE
Fix logic when creating a new story and setting the External URL at the same time.

### DIFF
--- a/osu_story.module
+++ b/osu_story.module
@@ -10,67 +10,90 @@ use Drupal\node\NodeInterface;
 use Drupal\redirect\Entity\Redirect;
 
 /**
- * Implements hook_ENTITY_TYPE_presave().
+ * Implements hook_ENTITY_TYPE_insert().
  *
- * For Story Nodes check if the External URL field is populated.
- * If so, update the meta-tags, exclude the story from the XML Sitemap,
- * and create a redirect to the external URL.
+ * After a new node is saved, we need to regenerate the XML Sitemap.
  */
-function osu_story_node_presave(NodeInterface $node) {
-  if ($node->bundle() == 'story') {
-    if (!$node->get('field_osu_story_external_url')->isEmpty()) {
-      $url_item = $node->get('field_osu_story_external_url')->first();
-      $external_url = $url_item ? $url_item->getUrl()->toString() : '';
-      // Meta tag updates.
-      if ($node->hasField('field_meta_tags')) {
-        $meta_tag_field = $node->get('field_meta_tags')->getValue();
-        if (!empty($meta_tag_field)) {
-          // Decode the JSON string.
-          $meta_tags = Json::decode($meta_tag_field[0]['value']);
-          // Update meta-tags for external story.
-          $meta_tags['canonical_url'] = $external_url;
-          $meta_tags['robots'] = 'noindex, nofollow';
-          $meta_tags['og_url'] = $external_url;
-          // Encode the JSON string.
-          $meta_tag_field[0]['value'] = Json::encode($meta_tags);
-          // Set the field value.
-          $node->set('field_meta_tags', json_encode($meta_tags));
-        }
-      }
-      // XML Sitemap, exclude this page.
-      $xmlsitemap_settings = $node->xmlsitemap;
-      $xmlsitemap_settings['status'] = FALSE;
-      $xmlsitemap_settings['status_override'] = 1;
-      $node->xmlsitemap = $xmlsitemap_settings;
-      // Create a redirect if one does not already exist for this nid and
-      // external url.
-      /** @var Drupal\redirect\RedirectRepository $redirect_repository */
-      $redirect_repository = \Drupal::service('redirect.repository');
-      $source_path = $node->toUrl()->getInternalPath();
-      $source_redirects = $redirect_repository->findBySourcePath($source_path);
-      $redirect_found = FALSE;
-      // Find the redirect if it already exists.
-      $language = $node->get('langcode')->value;
-      $urlHash = Redirect::generateHash($source_path, [], $language);
-      foreach ($source_redirects as $source_redirect) {
-        if ($source_redirect->getHash() == $urlHash) {
-          $redirect_found = TRUE;
-          break;
-        }
-      }
-      // We should only have one Redirect created for a given nid and
-      // external url.
-      if (!$redirect_found) {
-        $redirect_config = \Drupal::config('redirect.settings');
-        $redirect = Redirect::create();
-        $redirect->setSource($node->toUrl()->getInternalPath());
-        $redirect->setStatusCode($redirect_config->get('default_status_code'));
-        $redirect->setRedirect($external_url);
-        $redirect->save();
-      }
-      // Set a status message.
-      \Drupal::messenger()
-        ->addStatus(t('<p>This story has been marked as external.<br />Meta-tags have been updated, the story is excluded from the XML Sitemap, and a redirect to the external URL has been created to protect SEO.</p>'));
+function osu_story_node_insert(NodeInterface $node) {
+  if ($node->bundle() == 'story'
+    && $node->hasField('field_meta_tags')
+    && !$node->get('field_osu_story_external_url')->isEmpty()) {
+    $url_item = $node->get('field_osu_story_external_url')->first();
+    $external_url = $url_item ? $url_item->getUrl()->toString() : '';
+    _osu_story_ensure_story_redirect($node, $external_url);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ *
+ * On update, we need to regenerate the XML Sitemap.
+ */
+function osu_story_node_update(NodeInterface $node) {
+  if ($node->bundle() == 'story'
+    && !$node->get('field_osu_story_external_url')->isEmpty()) {
+    $url_item = $node->get('field_osu_story_external_url')->first();
+    $external_url = $url_item ? $url_item->getUrl()->toString() : '';
+    _osu_story_ensure_story_redirect($node, $external_url);
+  }
+}
+
+function _osu_story_ensure_story_redirect(NodeInterface $node, string $external_url): void {
+  // Meta tag updates.
+  if ($node->hasField('field_meta_tags')) {
+    $meta_tag_field = $node->get('field_meta_tags')->value;
+    // if the field is not empty, we will update only our fields.
+    if (!empty($meta_tag_field)) {
+      // Decode the JSON string.
+      $meta_tags = unserialize($meta_tag_field);
     }
+    // Nothing was manually set in metatag this will allow us to overwrite it.
+    else {
+      $meta_tags = [];
+    }
+    // Set Meatag data.
+    $meta_tags['canonical_url'] = $external_url;
+    $meta_tags['robots'] = 'noindex, nofollow';
+    $meta_tags['og_url'] = $external_url;
+    $node->set('field_meta_tags', serialize($meta_tags));
+  }
+  // XML Sitemap, exclude this page.
+  $xmlsitemap_settings = $node->xmlsitemap;
+  $xmlsitemap_settings['status'] = FALSE;
+  $xmlsitemap_settings['status_override'] = 1;
+  $node->xmlsitemap = $xmlsitemap_settings;
+  // Create a redirect if one does not already exist for this nid and
+  // external url.
+  /** @var Drupal\redirect\RedirectRepository $redirect_repository */
+  $redirect_repository = \Drupal::service('redirect.repository');
+  $source_path = $node->toUrl()->getInternalPath();
+  $source_redirects = $redirect_repository->findBySourcePath($source_path);
+  $redirect_found = FALSE;
+  // Find the redirect if it already exists.
+  $language = $node->get('langcode')->value;
+  $urlHash = Redirect::generateHash($source_path, [], $language);
+  foreach ($source_redirects as $source_redirect) {
+    if ($source_redirect->getHash() == $urlHash) {
+      $redirect_found = TRUE;
+      break;
+    }
+  }
+  // We should only have one Redirect created for a given nid and
+  // external url.
+  if (!$redirect_found) {
+    $redirect_config = \Drupal::config('redirect.settings');
+    $redirect = Redirect::create();
+    $redirect->setSource($node->toUrl()->getInternalPath());
+    $redirect->setStatusCode($redirect_config->get('default_status_code'));
+    $redirect->setRedirect($external_url);
+    $redirect->save();
+    // Set a status message.
+    \Drupal::messenger()
+      ->addStatus(t('<p>This story has been marked as external.<br />Meta-tags have been updated, the story is excluded from the XML Sitemap, and a redirect to the external URL has been created to protect SEO.</p>'));
+  }
+  else {
+    // Set a status message.
+    \Drupal::messenger()
+      ->addStatus(t('<p>This story has been marked as external.<br />Meta-tags have been updated, the story is excluded from the XML Sitemap.</p>'));
   }
 }

--- a/osu_story.module
+++ b/osu_story.module
@@ -5,7 +5,6 @@
  * OSU Story Module.
  */
 
-use Drupal\Component\Serialization\Json;
 use Drupal\node\NodeInterface;
 use Drupal\redirect\Entity\Redirect;
 
@@ -20,7 +19,7 @@ function osu_story_node_insert(NodeInterface $node) {
     && !$node->get('field_osu_story_external_url')->isEmpty()) {
     $url_item = $node->get('field_osu_story_external_url')->first();
     $external_url = $url_item ? $url_item->getUrl()->toString() : '';
-    _osu_story_ensure_story_redirect($node, $external_url);
+    _osu_story_update_story_redirects_set_xmlsitemap($node, $external_url);
   }
 }
 
@@ -34,11 +33,27 @@ function osu_story_node_update(NodeInterface $node) {
     && !$node->get('field_osu_story_external_url')->isEmpty()) {
     $url_item = $node->get('field_osu_story_external_url')->first();
     $external_url = $url_item ? $url_item->getUrl()->toString() : '';
-    _osu_story_ensure_story_redirect($node, $external_url);
+    _osu_story_update_story_redirects_set_xmlsitemap($node, $external_url);
   }
 }
 
-function _osu_story_ensure_story_redirect(NodeInterface $node, string $external_url): void {
+/**
+ * Updates the metatags, XML Sitemap settings, and redirects for external URLs.
+ *
+ * This method is used to mark a story node as external by:
+ * - Updating its meta tags with canonical URL, robots, and Open Graph URL
+ * values.
+ * - Excluding the story node from the XML Sitemap to prevent indexing.
+ * - Creating a redirect to an external URL, if one does not already exist.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   The story node entity to update.
+ * @param string $external_url
+ *   The external URL to set in meta tags and redirects.
+ *
+ * @return void
+ */
+function _osu_story_update_story_redirects_set_xmlsitemap(NodeInterface $node, string $external_url): void {
   // Meta tag updates.
   if ($node->hasField('field_meta_tags')) {
     $meta_tag_field = $node->get('field_meta_tags')->value;


### PR DESCRIPTION
Refactor story node hooks to separate insert and update logic, enhance redirect handling, and streamline meta tag and XML Sitemap updates.